### PR TITLE
Disable submission feature for unknown patterns

### DIFF
--- a/grml-tips
+++ b/grml-tips
@@ -150,71 +150,8 @@ if (@tips) {
     }
 }
 else {
-    say "Sorry, could not find a tip for '$pattern'. :-(\n\n",
-        "Do you want to submit the keyword '$pattern' to grml's keyword database?\n",
-        "The grml team will write tips for the most requested and useful keywords.\n",
-        "To use and contribute to this feature you'll need a working networking connection.\n",
-        "No personal data will be transmitted to the database.\n\n",
-        "Send \"$pattern\" to grml's keyword database? [y|N] ";
-
-    ReadMode 4;    # Turn off controls keys
-    my $x;
-    while ( not defined( $x = ReadKey(-1) ) ) {
-        Time::HiRes::sleep(0.5);
-    }
-    ReadMode 0;    # Reset tty mode before exiting
-    print "\n\n";
-    if ( $x =~ /(y|j)/i ) {
-        my $version;
-        if ( -f '/etc/grml_version' ) {
-            open( my $fh, '<', '/etc/grml_version' )
-                or die "Could not open /etc/grml_version: $!";
-            $version = <$fh>;
-            chomp $version;
-            close($fh);
-        }
-        elsif ( -f '/etc/debian_version' ) {
-            open( my $fh, '<', '/etc/debian_version' )
-                or die "Could not open /etc/debian_version: $!";
-            $version = <$fh>;
-            chomp $version;
-            close($fh);
-        }
-        else {
-            $version = 'unknown';
-        }
-        my $ua = new LWP::UserAgent;
-        $ua->agent("grml-tips 0.0 ");    # set the HTTP 'browser' type
-        my $res = $ua->post(
-            'http://deb.grml.org/~formorer/submissions/keyword.cgi',
-            [   'version' => $version,
-                'keyword' => $pattern
-            ],
-        );
-        if ( $res->is_success ) {
-            my $content = $res->decoded_content;
-            if ( $content =~ /Submission received/ ) {
-                say
-                    "Keyword '$pattern' has been submitted to grml's keyword database.\nThanks.";
-            }
-            else {
-                say "Your pattern could not be submitted.\n",
-                    "Please file a bug against grml-tips at ",
-                    "http://bts.grml.org/\n",
-                    "Thanks!";
-            }
-        }
-        else {
-            print "Could not submitt '$pattern': " . $res->status_line . "\n";
-        }
-
-    }
-    else {
-        print
-            "'$pattern' has not been sent to grml's keyword database as requested.\n";
-        print
-            "If you want to submit a tip please mail it to tips\@grml.org - thank you!\n";
-    }
+    say "Sorry, could not find a tip for '$pattern'. :-(\n",
+        "Feel free to submit a pull request at https://github.com/grml/grml-tips\n";
 }
 
 ## END OF FILE #################################################################


### PR DESCRIPTION
The web service that used to collect submissions for unknown tips/patters isn't active since long time (last submission seems to date back to 2012-04-16). No longer provide it, instead point users to pull request against the grml-tips git repository.