### PR TITLE
Make grml-tips start with 1 and add title to Tip #216

### DIFF
--- a/grml_tips
+++ b/grml_tips
@@ -1,3 +1,4 @@
+-- 
 Configure network:
 
 # grml-network
@@ -2620,22 +2621,25 @@ UTF-8 at grml / some general information regarding Unicde/UTF-8:
 
   http://wiki.grml.org/doku.php?id=utf8
 -- 
+Limit SSH connection attempts
 
-This allows one ssh connection attepmt per minute per source ip, with a initial
-burst of 10.  The available burst is like a counter which is initialised with
+This allows one SSH connection attempt per minute per source IP, with an initial
+burst of 10. The available burst is like a counter which is initialised with
 10. Every connection attempt decrements the counter, and every minute where the
 connection limit of one per minute is not overstepped the counter is
-incremented by one.  If the burst counter is exhausted the real rate limit
-comes into play. This gives you 11 connectionattepmts in the first minute
-before blocked for 10minutes.  After 10 minutes block the game restarts.
+incremented by one. If the burst counter is exhausted, the real rate limit
+comes into play. This gives you 11 connection attempts in the first minute
+before being blocked for 10 minutes. After the 10 minutes block, the game restarts.
 
 Hint: you could set the burst value to 5 and the block time to only 5 minutes
-to achive the same average connection rate but with halve the block time.
+to achieve the same average connection rate but with halve the block time.
 
 iptables -A inet_in -p tcp --syn --dport 22 -m hashlimit --hashlimit-name ssh \
          --hashlimit 1/minute \ --hashlimit-burst 10 --hashlimit-mode srcip   \
          --hashlimit-htable-expire 600000 -j ACCEPT
 iptables -A inet_in -p tcp --dport 22 -m state --state NEW -j REJECT
+
+Tags: network
 -- 
 Tunnel a specific connection via socat:
 


### PR DESCRIPTION
I tried to identify some kind of title for each of the Grml Tips with something like this:

```
  ❯ grep -e "^-- " -A1 grml_tips | grep -v -- "^--" | cat -n
```

This attempt did not display the first Grml Tip, so I added the "-- " before the first line. This had the side effect, that Grml Tips now start with 1 (instead of 0). I think this is better (unless we're referencing the Grml Tips from somewhere that I am not aware of).

This change will most probably affect the Grml Tips Hugo template which parses the grml_tips directly from Github, see:
https://github.com/grml/grml.org/blob/401cb9c1036c1432849ecbc54dcc57dd9027566d/content/tips/index.md?plain=1#L14

This should be changed anyway.

I then noticed that only one tip had no "title": #216. I came up with a title and, while at it, also fixed some typos in the description. I also added the tag 'network' for the tip.

The grml_tips list looks like this after the change:

```
  ❯ grep -e "^-- " -A1 grml_tips | grep -v -- "^--" | cat -n
       1  Configure network:
       2  Deactivate error correction of zsh:
       3  Disable automatic setting of title in GNU screen:
       4  Do not use menu completion in zsh:
       5  Run GNU screen with grml-configuration:
  [...]
     216  Limit SSH connection attempts
  [...]
     271  Install Archlinux using Grml:
     272  Export blockdevices via AoE (ATA over Ethernet):
     273  Access blockdevices via AoE (ATA over Ethernet):
     274  Check notebook's battery status:
     275  Change notebook's screen brightness:
```

Issues: grml/grml-tips#6, grml/grml-tips#7